### PR TITLE
Change script `prettyxhtml.sh` to use xmllint

### DIFF
--- a/prettyxhtml.sh
+++ b/prettyxhtml.sh
@@ -7,7 +7,7 @@
 #
 # redirect to file if needed (e.g. "... > prettier-file.xml")
 #
-# explanation of tidy flags: -i = indent, -q = quiet/surpress non-essential output
+# uses xmllint (available via package libxml2-utils)
 #
 
-cat "$1" | tidy -xml -iq
+xmllint -format "$1"


### PR DESCRIPTION
Tidy was causing problems with DOCTYPE declaration.
Switched to xmllint (available via package `libxml2-utils`) instead.